### PR TITLE
Create setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+sudo apt-get update;
+sudo apt-get install -y build-essential libssl-dev;
+
+curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh -o install_nvm.sh;
+bash install_nvm.sh;
+source ~/.profile;
+nvm install 4.8.0;
+nvm use 4.8.0;
+
+wget https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz;
+sudo tar -xvf go1.7.linux-amd64.tar.gz;
+sudo cp -r go/ /usr/local/;
+sudo rm -rf go/ go1.7.linux-amd64.tar.gz;
+
+export GOROOT=/usr/local/go;
+export GOPATH=$HOME/projects/go;
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH;
+
+sudo apt-get install -y software-properties-common;
+sudo add-apt-repository -y ppa:ethereum/ethereum;
+sudo apt-get update;
+sudo apt-get install -y ethereum;
+
+git clone https://github.com/jpmorganchase/quorum.git;
+cd quorum/;
+make all;
+echo "PATH=\$PATH:"$PWD/build/bin >> ~/.bashrc;
+source ~/.bashrc;
+
+cd ..;
+mkdir constellation && cd constellation/;
+sudo apt-get install libdb-dev libsodium-dev zlib1g-dev libtinfo-dev unzip;
+wget https://github.com/jpmorganchase/constellation/releases/download/v0.0.1-alpha/ubuntu1604.zip;
+unzip ubuntu1604.zip;
+chmod +x ubuntu1604/constellation-node;
+chmod +x ubuntu1604/constellation-enclave-keygen;
+echo "PATH=\$PATH:"$PWD/ubuntu1604 >> ~/.bashrc;
+source ~/.bashrc;
+
+cd ..;
+git clone https://github.com/davebryson/quorum-genesis.git;
+cd quorum-genesis/;
+npm install -g;
+
+cd ..;
+git clone https://github.com/coeniebeyers/QuorumNetworkManager.git;
+cd QuorumNetworkManager/;
+npm install;


### PR DESCRIPTION
A straightforward bash script that, when run, will get everything you need to start or join a Quorum network.
It uses nvm to manage node (set to `node v4.8.0` and `npm v2.15.11`), but you can change those versions easily once the install is done to any you like with:

`nvm install 6.x.x` (or 5.x., 7.x.x, whatever)
`nvm use <your_choice_above>`